### PR TITLE
[FIX] Upgrade use of slurp with Mojo::File package

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Mojo::MySQL5
 
+0.10     Mon Set 17 14:08:05 2018
+       * Upgraded use of slurp with Mojo::File package.
+       * Set default charset and default collate for mojo lite and migration tests.
+
 0.09     Sat May  2 17:52:05 2015
        * Added module Mojo::MySQL5::PubSub.
        * Added pubsub attribute to Mojo::MySQL5.

--- a/lib/Mojo/MySQL5.pm
+++ b/lib/Mojo/MySQL5.pm
@@ -21,7 +21,7 @@ has pubsub => sub {
 };
 has url             => sub { Mojo::MySQL5::URL->new('mysql:///test') };
 
-our $VERSION = '0.09';
+our $VERSION = '0.10';
 
 sub db {
   my $self = shift;

--- a/lib/Mojo/MySQL5/Migrations.pm
+++ b/lib/Mojo/MySQL5/Migrations.pm
@@ -3,7 +3,8 @@ use Mojo::Base -base;
 
 use Carp 'croak';
 use Mojo::Loader 'data_section';
-use Mojo::Util qw(decode slurp);
+use Mojo::Util qw(decode);
+use Mojo::File qw(path);
 use Encode '_utf8_off';
 
 use constant DEBUG => $ENV{MOJO_MIGRATIONS_DEBUG} || 0;
@@ -19,7 +20,12 @@ sub from_data {
     data_section($class //= caller, $name // $self->name));
 }
 
-sub from_file { shift->from_string(decode 'UTF-8', slurp pop) }
+sub from_file {
+  my ($self, $file) = @_;
+  my $path = path($file);
+  my $bytes = $path->slurp;
+  shift->from_string(decode 'UTF-8', $bytes)
+}
 
 sub from_string {
   my ($self, $sql) = @_;

--- a/t/migrations.t
+++ b/t/migrations.t
@@ -42,7 +42,7 @@ is $mysql->migrations->name('test2')->from_data(__PACKAGE__)->latest, 2,
 # Different syntax variations
 $mysql->migrations->name('migrations_test')->from_string(<<EOF);
 -- 1 up
-create table if not exists migration_test_one (foo varchar(255));
+create table if not exists migration_test_one (foo varchar(255)) default charset=utf8 default collate utf8_unicode_ci;
 
 -- 1down
 

--- a/t/migrations/test.sql
+++ b/t/migrations/test.sql
@@ -1,5 +1,5 @@
 -- 1 up
-create table if not exists migration_test_three (baz varchar(255));
+create table if not exists migration_test_three (baz varchar(255)) default charset=utf8 default collate utf8_unicode_ci;
 -- 1 down
 drop table if exists migration_test_three;
 -- 2 up

--- a/t/mysql_lite_app.t
+++ b/t/mysql_lite_app.t
@@ -56,7 +56,7 @@ done_testing();
 __DATA__
 @@ app_test
 -- 1 up
-create table if not exists app_test (stuff text);
+create table if not exists app_test (stuff text) default charset=utf8 default collate utf8_unicode_ci;
 delimiter //
 create procedure mojo_app_test()
   deterministic reads sql data


### PR DESCRIPTION
Mojolicious 7.31 deprecated slurp on Mojo::Util. This pull request adapt Mojo::MYSQL5 for compatibility with the Mojolicious last version.

Additionally, this pull request ensure collation for tables created on migrations tests.